### PR TITLE
 Fix bug with local alignment finding no match

### DIFF
--- a/src/Bio/Chain/Alignment.hs
+++ b/src/Bio/Chain/Alignment.hs
@@ -69,9 +69,9 @@ align algo s t = AlignmentResult alignmentScore alignmentResult s t
     -- alignment we get couple of matches in the middle of two chains: [MATCH 5 7, MATCH 6 8].
     -- This list doesn't tell us how to get the seconds chain from the first. Obviously before
     -- matching we need to delete first four symbols from chain one and insert six symbols from
-    -- chain two. And of course there are symbols left after match in both chains. And with them
-    -- we need to do the same. First delete left symbols from the first chain and then insert
-    -- left symbols from the second chain.
+    -- chain two. And of course there are symbols remaining after match in both chains. And with
+    -- them we need to do the same. First delete remaining symbols from the first chain and then
+    -- insert remaining symbols from the second chain.
     --
     -- Local                   Semiglobal              Global
     -- +------------------+    +-----------------+     +------------------+

--- a/src/Bio/Chain/Alignment.hs
+++ b/src/Bio/Chain/Alignment.hs
@@ -65,11 +65,13 @@ align algo s t = AlignmentResult alignmentScore alignmentResult s t
     -- and always reaches it.
     --
     -- Each step represents some operation: insert, delete or match. So image the path doesn't
-    -- start in bottom right cell or doesn't end in top left cell. That means we don't get complete
-    -- list of operations. Thus we need to complete it. If path doesn't start at bottom right
-    -- corner then we need to append deletions or insertions of what's left in the end of chains.
-    -- The order doesn't matter. If path doesn't end at top left cornder then we need to prepend
-    -- deletions or insertions of what's left in the beginning of chains.
+    -- start in bottom right cell or doesn't end in top left cell. For example in case of local
+    -- alignment we get couple of matches in the middle of two chains: [MATCH 5 7, MATCH 6 8].
+    -- This list doesn't tell us how to get the seconds chain from the first. Obviously before
+    -- matching we need to delete first four symbols from chain one and insert six symbols from
+    -- chain two. And of course there are symbols left after match in both chains. And with them
+    -- we need to do the same. First delete left symbols from the first chain and then insert
+    -- left symbols from the second chain.
     --
     -- Local                   Semiglobal              Global
     -- +------------------+    +-----------------+     +------------------+

--- a/src/Bio/Chain/Alignment.hs
+++ b/src/Bio/Chain/Alignment.hs
@@ -19,7 +19,6 @@ import           Bio.Chain.Alignment.Algorithms
 import           Bio.Chain.Alignment.Type
 import           Bio.Utils.Geometry             (R)
 import           Bio.Utils.Monomer              (Symbol (..))
-import           Debug.Trace
 
 -- | Align chains using specifed algorithm
 --

--- a/src/Bio/Chain/Alignment/Algorithms.hs
+++ b/src/Bio/Chain/Alignment/Algorithms.hs
@@ -404,6 +404,10 @@ instance SequenceAlignment (SemiglobalAlignment AffineGap) where
         result :: Int
         result = if | i == lowerS -> 0
                     | j == lowerT -> 0
-                    | k == Insert && maxIxValue == insertion -> succ insertions
-                    | k == Delete && maxIxValue == deletion  -> succ deletions
+                    | k == Insert -> if maxIxValue == insertion
+                                        then succ insertions
+                                        else 0
+                    | k == Delete -> if maxIxValue == deletion
+                                        then succ deletions
+                                        else 0
                     | otherwise -> maxIxValue

--- a/src/Bio/Chain/Alignment/Algorithms.hs
+++ b/src/Bio/Chain/Alignment/Algorithms.hs
@@ -97,7 +97,9 @@ defStart m _ _ = let ((_, _, _), (upperS, upperT, _)) = A.bounds m in (upperS, u
 -- | Default start condition for traceback in local alignment.
 --
 localStart :: (Alignable m, Alignable m') => Matrix m m' -> m -> m' -> (Index m, Index m')
-localStart m _ _ = (\(a, b, _) -> (a, b)) $ maximumBy (comparing (m !)) $ A.range (A.bounds m)
+localStart m _ _ = let ((lowerS, lowerT, _), (upperS, upperT, _)) = A.bounds m
+                       range' = A.range ((lowerS, lowerT, Match), (upperS, upperT, Match))
+                   in  (\(a, b, _) -> (a, b)) $ maximumBy (comparing (m !)) range'
 
 -- | Default start condition for traceback in semiglobal alignment.
 --

--- a/src/Bio/Chain/Alignment/Algorithms.hs
+++ b/src/Bio/Chain/Alignment/Algorithms.hs
@@ -303,8 +303,8 @@ instance SequenceAlignment (GlobalAlignment AffineGap) where
         result :: Int
         result = if | i == lowerS -> gapOpen + gapExtend * index (lowerT, succ upperT) j
                     | j == lowerT -> gapOpen + gapExtend * index (lowerS, succ upperS) i
-                    | k == Insert && maxIxValue == insertion -> succ insertions
-                    | k == Delete && maxIxValue == deletion  -> succ deletions
+                    | k == Insert -> if maxIxValue == insertion then succ insertions else 0
+                    | k == Delete -> if maxIxValue == deletion then succ deletions else 0
                     | otherwise -> maxIxValue
 
 
@@ -350,11 +350,12 @@ instance SequenceAlignment (LocalAlignment AffineGap) where
 
         maxIxValue :: Int
         maxIxValue = maximum [replacement, insertion, deletion, 0]
+
         result :: Int
         result = if | i == lowerS -> 0
                     | j == lowerT -> 0
-                    | k == Insert && maxIxValue == insertion -> succ insertions
-                    | k == Delete && maxIxValue == deletion  -> succ deletions
+                    | k == Insert -> if maxIxValue == insertion then succ insertions else 0
+                    | k == Delete -> if maxIxValue == deletion then succ deletions else 0
                     | otherwise -> maxIxValue
 
 instance SequenceAlignment (SemiglobalAlignment AffineGap) where
@@ -401,13 +402,10 @@ instance SequenceAlignment (SemiglobalAlignment AffineGap) where
 
         maxIxValue :: Int
         maxIxValue = maximum [replacement, insertion, deletion]
+
         result :: Int
         result = if | i == lowerS -> 0
                     | j == lowerT -> 0
-                    | k == Insert -> if maxIxValue == insertion
-                                        then succ insertions
-                                        else 0
-                    | k == Delete -> if maxIxValue == deletion
-                                        then succ deletions
-                                        else 0
+                    | k == Insert -> if maxIxValue == insertion then succ insertions else 0
+                    | k == Delete -> if maxIxValue == deletion then succ deletions else 0
                     | otherwise -> maxIxValue

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -200,8 +200,8 @@ affineSpec = describe "Affine gap and simple gap work differently" $ do
         let b = "AAATTTTTTTTTTTTTTTTATTTTTTTTTTTTAATTTTTTTTTTTT"
         let a' = "ATAAAAAAAAAAATTTTTTTTTTTATTTTTTTTTTTTATTTTTTTTTTTTTT"
         let b' = "-----AAATTTTTTTTTTTTTTTTATTTTTTTTTTTTAATTTTTTTTTTTT-"
-        let a'' = "ATAAAAAAAAAAATTTTTTTTTTTATTTTT-TTTTTTTATTTTT--TTTTTTTTT---"
-        let b'' = "----------AAATTTTTTTTTTT-TTTTTATTTTTTT-TTTTTAATTTTTTTTTTTT"
+        let a'' = "ATAAAAAAAAAAATTTTTTTTTTTATTTTTTTTTTTTATTTTTTTTTTTTTT"
+        let b'' = "-----AAATTTTTTTTTTTTTTTTATTTTTTTTTTTTAATTTTTTTTTTTT-"
         viewAlignment (alignSemiglobal a b) `shouldBe` (a', b')
         viewAlignment (alignSemiglobalAffine a b) `shouldBe` (a'', b'')
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,6 +12,8 @@ import           Bio.Utils.Geometry
 import           Bio.Protein.AminoAcid
 import           Bio.Protein.Chain
 import           Bio.Protein.Chain.Builder
+import           Bio.Chain.Alignment.Type
+import           Bio.Chain.Alignment.Scoring
 
 buildChainSpec :: Spec
 buildChainSpec = describe "Chain builder (BBT)" $ do
@@ -74,27 +76,153 @@ lensesSpec = describe "Amino acid lenses" $ do
         aa ^. c . atom `shouldBe` "C"
         aa ^. o . atom `shouldBe` "O"
 
+alignLocal :: String -> String -> AlignmentResult String String
+alignLocal = align (LocalAlignment nuc44 (-10 :: SimpleGap))
+
+alignGlobal :: String -> String -> AlignmentResult String String
+alignGlobal = align (GlobalAlignment nuc44 (-10 :: SimpleGap))
+
+alignSemiglobal :: String -> String -> AlignmentResult String String
+alignSemiglobal = align (SemiglobalAlignment nuc44 (-10 :: SimpleGap))
+
+alignLocalAffine:: String -> String -> AlignmentResult String String
+alignLocalAffine = align (LocalAlignment nuc44 (AffineGap (-10) (-1)))
+
+alignGlobalAffine :: String -> String -> AlignmentResult String String
+alignGlobalAffine = align (GlobalAlignment nuc44 (AffineGap (-10) (-1)))
+
+alignSemiglobalAffine :: String -> String -> AlignmentResult String String
+alignSemiglobalAffine = align (SemiglobalAlignment nuc44 (AffineGap (-10) (-1)))
+
+alignAllSpec :: String -> String -> [(String, String)] -> Spec
+alignAllSpec a b expected = do
+    alignLocalSpec a b expected
+    alignGlobalSpec a b expected
+    alignSemiglobalSpec a b expected
+
+alignGlobalSpec :: String -> String -> [(String, String)] -> Spec
+alignGlobalSpec a b expected = do
+    it "Global" $ do
+        viewAlignment (alignGlobal a b) `shouldSatisfy` (flip elem expected)
+    it "Global with Affine gap " $ do
+        viewAlignment (alignGlobalAffine a b) `shouldSatisfy` (flip elem expected)
+
+alignLocalSpec :: String -> String -> [(String, String)] -> Spec
+alignLocalSpec a b expected = do
+    it "Local" $ do
+        viewAlignment (alignLocal a b) `shouldSatisfy` (flip elem expected)
+    it "Local with Affine gap" $ do
+        viewAlignment (alignLocalAffine a b) `shouldSatisfy` (flip elem expected)
+
+alignSemiglobalSpec :: String -> String -> [(String, String)] -> Spec
+alignSemiglobalSpec a b expected = do
+    it "Semiglobal" $ do
+        viewAlignment (alignSemiglobal a b) `shouldSatisfy` (flip elem expected)
+    it "Semiglobal with Affine gap" $ do
+        viewAlignment (alignSemiglobalAffine a b) `shouldSatisfy` (flip elem expected)
+
+sameForAllSpec :: Spec
+sameForAllSpec = describe "Should work for all algorithms" $ do
+    describe "Align single letter over itself" $ do
+        alignAllSpec "A" "A" [("A", "A")]
+    describe "Align several letters over itself" $ do
+        alignAllSpec "ATGC" "ATGC" [("ATGC", "ATGC")]
+    describe "Align single letter over mismatched one" $ do
+        let a = "A"
+        let b = "G"
+        let expected = [("-A", "G-"), ("A-", "-G")]
+        alignLocalSpec a b expected
+        alignSemiglobalSpec a b expected
+        alignGlobalSpec a b (("A", "G") : expected)
+    describe "Align multiple letters without match" $ do
+        let a = "ATATA"
+        let b = "GCGCG"
+        let expected = [("-----ATATA", "GCGCG-----"), ("ATATA-----", "-----GCGCG")]
+        alignLocalSpec a b expected
+        alignSemiglobalSpec a b expected
+        alignGlobalSpec a b (("ATATA", "GCGCG") : expected)
+    describe "Align internal similarity" $ do
+        alignAllSpec "ATGCATGCATGC" "CATGCA" [("ATGCATGCATGC", "---CATGCA---")]
+    describe "Align prefix similarity" $ do
+        alignAllSpec "ATGCATGCATGC" "ATGCATGCA" [("ATGCATGCATGC", "ATGCATGCA---")]
+    describe "Align suffix similarity" $ do
+        alignAllSpec "ATGCATGCATGC" "CATGCATGC" [("ATGCATGCATGC", "---CATGCATGC")]
+
 semiglobalSpec :: Spec
 semiglobalSpec = describe "Semiglobal alignment" $ do
     it "may not end with MATCH (single letter)" $ do
-        let result = alignSemiglobal "a" "z"
-        show (viewAlignment result) `shouldBe` "(\"a-\",\"-z\")"
+        let result = alignSemiglobal' "a" "z"
+        viewAlignment result `shouldBe` ("a-", "-z")
     it "may not end with MATCH (many letters)" $ do
-        let result = alignSemiglobal "abide" "vwiyz"
-        show (viewAlignment result) `shouldBe` "(\"abide-----\",\"-----vwiyz\")"
+        let result = alignSemiglobal' "abide" "vwiyz"
+        viewAlignment result `shouldBe` ("abide-----", "-----vwiyz")
     it "may not end with MATCH (many letters and have match in the middle)" $ do
-        let result = alignSemiglobal "aaabb" "bbzzz"
-        show (viewAlignment result) `shouldBe` "(\"aaabb---\",\"---bbzzz\")"
+        let result = alignSemiglobal' "aaabb" "bbzzz"
+        viewAlignment result `shouldBe` ("aaabb---", "---bbzzz")
     it "may not end with MATCH (many letters and have match in the middle and gaps)" $ do
-        let result = alignSemiglobal "900009" "00000"
-        show (viewAlignment result) `shouldBe` "(\"900009-\",\"-0000-0\")"
+        let result = alignSemiglobal' "900009" "00000"
+        viewAlignment result `shouldBe` ("900009-", "-0000-0")
   where
-    alignSemiglobal :: String -> String -> AlignmentResult String String
-    alignSemiglobal =
+    alignSemiglobal' :: String -> String -> AlignmentResult String String
+    alignSemiglobal' =
         align (SemiglobalAlignment (\a b -> 4 - abs (ord a - ord b)) (AffineGap (-2) (-1)))
+
+affineSpec :: Spec
+affineSpec = describe "Affine gap and simple gap work differently" $ do
+    it "local alignment" $ do
+        let a = "AATTTAA"
+        let b = "AAAA"
+        viewAlignment (alignLocal a b) `shouldBe` ("AATTT--AA", "-----AAAA")
+        viewAlignment (alignLocalAffine a b) `shouldBe` ("AATTTAA", "AA---AA")
+    it "global alignment" $ do
+        let a = "AAAAAAAAATTTTTTTTTTATTTTTTTTTAATTTTTTTTTTTTTTTTTTT"
+        let b = "TTTTTTTTTTATAAAAAAAAAAATTTTTTTTTTTTATTTTTTTTTTTTT"
+        let a' = "AAAAAAAAATTTTTTTTTTATTTTTTTTTAATTTTTTTTTTTTTTTTTTT"
+        let b' = "TTTTTTTTTTATAAAAAAAAAAATTTTTTT-TTTTTATTTTTTTTTTTTT"
+        let a'' = "AAAAAAAAATTTTTTTTTTAT-----------TTTTTTTTAATTTT-TTTTTTTTTTTTTTT"
+        let b'' = "---------TTTTTTTTTTATAAAAAAAAAAATTTTTTTT--TTTTATTTTTTTTTTTTT--"
+        viewAlignment (alignGlobal a b) `shouldBe` (a', b')
+        viewAlignment (alignGlobalAffine a b) `shouldBe` (a'', b'')
+    it "semiglobal alignment" $ do
+        let a = "ATAAAAAAAAAAATTTTTTTTTTTATTTTTTTTTTTTATTTTTTTTTTTTTT"
+        let b = "AAATTTTTTTTTTTTTTTTATTTTTTTTTTTTAATTTTTTTTTTTT"
+        let a' = "ATAAAAAAAAAAATTTTTTTTTTTATTTTTTTTTTTTATTTTTTTTTTTTTT"
+        let b' = "-----AAATTTTTTTTTTTTTTTTATTTTTTTTTTTTAATTTTTTTTTTTT-"
+        let a'' = "ATAAAAAAAAAAATTTTTTTTTTTATTTTT-TTTTTTTATTTTT--TTTTTTTTT---"
+        let b'' = "----------AAATTTTTTTTTTT-TTTTTATTTTTTT-TTTTTAATTTTTTTTTTTT"
+        viewAlignment (alignSemiglobal a b) `shouldBe` (a', b')
+        viewAlignment (alignSemiglobalAffine a b) `shouldBe` (a'', b'')
+
+alignmentSanitySpec  :: Spec
+alignmentSanitySpec = describe "Sanity tests" $ do
+    describe "Local alignment works" $ do
+        let a = "TTTTTTTTAAAAAATTTTTTTTTTTT"
+        let b = "CCCCCCCCCCCCCAAAAAACCCCCCCCCCC"
+        let a' = "TTTTTTTT-------------AAAAAATTTTTTTTTTTT-----------"
+        let b' = "--------CCCCCCCCCCCCCAAAAAA------------CCCCCCCCCCC"
+        alignLocalSpec a b [(a', b')]
+    describe "Global alignment works" $ do
+        let a = "AAAAAAAAACCCAAAAAAACCCAAAAAAAA"
+        let b = "AAAAAACCCAAAAAACCAAAAAAA"
+        let a' = "AAAAAAAAACCCAAAAAAACCCAAAAAAAA"
+        let b' = "AAAAAA---CCCAAAAAA-CC-AAAAAAA-"
+        alignGlobalSpec a b [(a', b')]
+    describe "Semiglobal alignment works" $ do
+        let a = "AAAAAAAAAATTTTTTTTTTT"
+        let b = "TTTTTTTTTCCCCCCCCCCC"
+        let a' = "AAAAAAAAAATTTTTTTTTTT-----------"
+        let b' = "------------TTTTTTTTTCCCCCCCCCCC"
+        alignSemiglobalSpec a b [(a', b')]
+
+alignmentSpec :: Spec
+alignmentSpec = describe "Alignment" $ do
+    sameForAllSpec
+    semiglobalSpec
+    affineSpec
+    alignmentSanitySpec
 
 main :: IO ()
 main = hspec $ do
     lensesSpec
     buildChainSpec
-    semiglobalSpec
+    alignmentSpec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -103,23 +103,23 @@ alignAllSpec a b expected = do
 alignGlobalSpec :: String -> String -> [(String, String)] -> Spec
 alignGlobalSpec a b expected = do
     it "Global" $ do
-        viewAlignment (alignGlobal a b) `shouldSatisfy` (flip elem expected)
+        expected `shouldContain` [viewAlignment (alignGlobal a b)]
     it "Global with Affine gap " $ do
-        viewAlignment (alignGlobalAffine a b) `shouldSatisfy` (flip elem expected)
+        expected `shouldContain` [viewAlignment (alignGlobalAffine a b)]
 
 alignLocalSpec :: String -> String -> [(String, String)] -> Spec
 alignLocalSpec a b expected = do
     it "Local" $ do
-        viewAlignment (alignLocal a b) `shouldSatisfy` (flip elem expected)
+        expected `shouldContain` [viewAlignment (alignLocal a b)]
     it "Local with Affine gap" $ do
-        viewAlignment (alignLocalAffine a b) `shouldSatisfy` (flip elem expected)
+        expected `shouldContain` [viewAlignment (alignLocalAffine a b)]
 
 alignSemiglobalSpec :: String -> String -> [(String, String)] -> Spec
 alignSemiglobalSpec a b expected = do
     it "Semiglobal" $ do
-        viewAlignment (alignSemiglobal a b) `shouldSatisfy` (flip elem expected)
+        expected `shouldContain` [viewAlignment (alignSemiglobal a b)]
     it "Semiglobal with Affine gap" $ do
-        viewAlignment (alignSemiglobalAffine a b) `shouldSatisfy` (flip elem expected)
+        expected `shouldContain` [viewAlignment (alignSemiglobalAffine a b)]
 
 sameForAllSpec :: Spec
 sameForAllSpec = describe "Should work for all algorithms" $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -130,23 +130,37 @@ sameForAllSpec = describe "Should work for all algorithms" $ do
     describe "Align single letter over mismatched one" $ do
         let a = "A"
         let b = "G"
-        let expected = [("-A", "G-"), ("A-", "-G")]
-        alignLocalSpec a b expected
-        alignSemiglobalSpec a b expected
-        alignGlobalSpec a b (("A", "G") : expected)
+        alignLocalSpec a b [("", "")]
+        alignSemiglobalSpec a b [("-A", "G-"), ("A-", "-G")]
+        alignGlobalSpec a b [("A", "G"), ("-A", "G-"), ("A-", "-G")]
     describe "Align multiple letters without match" $ do
         let a = "ATATA"
         let b = "GCGCG"
         let expected = [("-----ATATA", "GCGCG-----"), ("ATATA-----", "-----GCGCG")]
-        alignLocalSpec a b expected
+        alignLocalSpec a b [("", "")]
         alignSemiglobalSpec a b expected
         alignGlobalSpec a b (("ATATA", "GCGCG") : expected)
     describe "Align internal similarity" $ do
-        alignAllSpec "ATGCATGCATGC" "CATGCA" [("ATGCATGCATGC", "---CATGCA---")]
+        let a = "ATGCATGCATGC"
+        let b = "CATGCA"
+        let expected = [("ATGCATGCATGC", "---CATGCA---")]
+        alignLocalSpec a b [("CATGCA", "CATGCA")]
+        alignSemiglobalSpec a b expected
+        alignGlobalSpec a b expected
     describe "Align prefix similarity" $ do
-        alignAllSpec "ATGCATGCATGC" "ATGCATGCA" [("ATGCATGCATGC", "ATGCATGCA---")]
+        let a = "ATGCATGCATGC"
+        let b = "ATGCATGCA"
+        let expected = [("ATGCATGCATGC", "ATGCATGCA---")]
+        alignLocalSpec a b [("ATGCATGCA", "ATGCATGCA")]
+        alignSemiglobalSpec a b expected
+        alignGlobalSpec a b expected
     describe "Align suffix similarity" $ do
-        alignAllSpec "ATGCATGCATGC" "CATGCATGC" [("ATGCATGCATGC", "---CATGCATGC")]
+        let a = "ATGCATGCATGC"
+        let b = "CATGCATGC"
+        let expected = [("ATGCATGCATGC", "---CATGCATGC")]
+        alignLocalSpec a b [("CATGCATGC", "CATGCATGC")]
+        alignSemiglobalSpec a b expected
+        alignGlobalSpec a b expected
 
 semiglobalSpec :: Spec
 semiglobalSpec = describe "Semiglobal alignment" $ do
@@ -172,7 +186,7 @@ affineSpec = describe "Affine gap and simple gap work differently" $ do
     it "local alignment" $ do
         let a = "AATTTAA"
         let b = "AAAA"
-        viewAlignment (alignLocal a b) `shouldBe` ("AATTT--AA", "-----AAAA")
+        viewAlignment (alignLocal a b) `shouldBe` ("AA", "AA")
         viewAlignment (alignLocalAffine a b) `shouldBe` ("AATTTAA", "AA---AA")
     it "global alignment" $ do
         let a = "AAAAAAAAATTTTTTTTTTATTTTTTTTTAATTTTTTTTTTTTTTTTTTT"
@@ -198,8 +212,8 @@ alignmentSanitySpec = describe "Sanity tests" $ do
     describe "Local alignment works" $ do
         let a = "TTTTTTTTAAAAAATTTTTTTTTTTT"
         let b = "CCCCCCCCCCCCCAAAAAACCCCCCCCCCC"
-        let a' = "TTTTTTTT-------------AAAAAATTTTTTTTTTTT-----------"
-        let b' = "--------CCCCCCCCCCCCCAAAAAA------------CCCCCCCCCCC"
+        let a' = "AAAAAA"
+        let b' = "AAAAAA"
         alignLocalSpec a b [(a', b')]
     describe "Global alignment works" $ do
         let a = "AAAAAAAAACCCAAAAAAACCCAAAAAAAA"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -121,8 +121,8 @@ alignSemiglobalSpec a b expected = do
     it "Semiglobal with Affine gap" $ do
         expected `shouldContain` [viewAlignment (alignSemiglobalAffine a b)]
 
-sameForAllSpec :: Spec
-sameForAllSpec = describe "Should work for all algorithms" $ do
+smallAlignmentSpec :: Spec
+smallAlignmentSpec = describe "Should work for all algorithms" $ do
     describe "Align single letter over itself" $ do
         alignAllSpec "A" "A" [("A", "A")]
     describe "Align several letters over itself" $ do
@@ -165,21 +165,19 @@ sameForAllSpec = describe "Should work for all algorithms" $ do
 semiglobalSpec :: Spec
 semiglobalSpec = describe "Semiglobal alignment" $ do
     it "may not end with MATCH (single letter)" $ do
-        let result = alignSemiglobal' "a" "z"
-        viewAlignment result `shouldBe` ("a-", "-z")
+        let result = alignSemiglobal "A" "T"
+        viewAlignment result `shouldBe` ("A-", "-T")
     it "may not end with MATCH (many letters)" $ do
-        let result = alignSemiglobal' "abide" "vwiyz"
-        viewAlignment result `shouldBe` ("abide-----", "-----vwiyz")
+        let result = alignSemiglobal "ATAT" "GCGC"
+        viewAlignment result `shouldBe` ("ATAT----", "----GCGC")
     it "may not end with MATCH (many letters and have match in the middle)" $ do
-        let result = alignSemiglobal' "aaabb" "bbzzz"
-        viewAlignment result `shouldBe` ("aaabb---", "---bbzzz")
+        let result = alignSemiglobal "AAATT" "TTGGG"
+        viewAlignment result `shouldBe` ("AAATT---", "---TTGGG")
     it "may not end with MATCH (many letters and have match in the middle and gaps)" $ do
-        let result = alignSemiglobal' "900009" "00000"
-        viewAlignment result `shouldBe` ("900009-", "-0000-0")
-  where
-    alignSemiglobal' :: String -> String -> AlignmentResult String String
-    alignSemiglobal' =
-        align (SemiglobalAlignment (\a b -> 4 - abs (ord a - ord b)) (AffineGap (-2) (-1)))
+        let result = alignSemiglobal "CCCCCCCATGAGATAGATA" "ATGACCGATAGATAGGGGGG"
+        let a = "CCCCCCCATGA--GATAGATA------"
+        let b = "-------ATGACCGATAGATAGGGGGG"
+        viewAlignment result `shouldBe` (a, b)
 
 affineSpec :: Spec
 affineSpec = describe "Affine gap and simple gap work differently" $ do
@@ -230,9 +228,9 @@ alignmentSanitySpec = describe "Sanity tests" $ do
 
 alignmentSpec :: Spec
 alignmentSpec = describe "Alignment" $ do
-    sameForAllSpec
-    semiglobalSpec
     affineSpec
+    semiglobalSpec
+    smallAlignmentSpec
     alignmentSanitySpec
 
 main :: IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -182,17 +182,17 @@ semiglobalSpec = describe "Semiglobal alignment" $ do
 affineSpec :: Spec
 affineSpec = describe "Affine gap and simple gap work differently" $ do
     it "local alignment" $ do
-        let a = "AATTTAA"
-        let b = "AAAA"
-        viewAlignment (alignLocal a b) `shouldBe` ("AA", "AA")
-        viewAlignment (alignLocalAffine a b) `shouldBe` ("AATTTAA", "AA---AA")
+        let a = "CCCCCCATGATGACCCCCC"
+        let b = "TTTTTTATGAGGGGTGAGGGGGG"
+        viewAlignment (alignLocal a b) `shouldBe` ("TGATGA", "TTATGA")
+        viewAlignment (alignLocalAffine a b) `shouldBe` ("ATGA----TGA", "ATGAGGGGTGA")
     it "global alignment" $ do
         let a = "AAAAAAAAATTTTTTTTTTATTTTTTTTTAATTTTTTTTTTTTTTTTTTT"
         let b = "TTTTTTTTTTATAAAAAAAAAAATTTTTTTTTTTTATTTTTTTTTTTTT"
         let a' = "AAAAAAAAATTTTTTTTTTATTTTTTTTTAATTTTTTTTTTTTTTTTTTT"
         let b' = "TTTTTTTTTTATAAAAAAAAAAATTTTTTT-TTTTTATTTTTTTTTTTTT"
-        let a'' = "AAAAAAAAATTTTTTTTTTAT-----------TTTTTTTTAATTTT-TTTTTTTTTTTTTTT"
-        let b'' = "---------TTTTTTTTTTATAAAAAAAAAAATTTTTTTT--TTTTATTTTTTTTTTTTT--"
+        let a'' = "AAAAAAAAATTTTTTTTTTAT-----------TTTTTTTTAATTTTTTTTTTTTTTTTTTT"
+        let b'' = "---------TTTTTTTTTTATAAAAAAAAAAATTTTTTTT---TTTTATTTTTTTTTTTTT"
         viewAlignment (alignGlobal a b) `shouldBe` (a', b')
         viewAlignment (alignGlobalAffine a b) `shouldBe` (a'', b'')
     it "semiglobal alignment" $ do
@@ -214,10 +214,10 @@ alignmentSanitySpec = describe "Sanity tests" $ do
         let b' = "AAAAAA"
         alignLocalSpec a b [(a', b')]
     describe "Global alignment works" $ do
-        let a = "AAAAAAAAACCCAAAAAAACCCAAAAAAAA"
-        let b = "AAAAAACCCAAAAAACCAAAAAAA"
-        let a' = "AAAAAAAAACCCAAAAAAACCCAAAAAAAA"
-        let b' = "AAAAAA---CCCAAAAAA-CC-AAAAAAA-"
+        let a = "AAAAAATAAAAAACAAAAAGAAA"
+        let b = "AAAAGAAAAGAAAAAAACAAAAA"
+        let a' = "AAAAAATAAAAAACAAAAAGAAA"
+        let b' = "AAAAGAAAAGAAAAAAACAAAAA"
         alignGlobalSpec a b [(a', b')]
     describe "Semiglobal alignment works" $ do
         let a = "AAAAAAAAAATTTTTTTTTTT"


### PR DESCRIPTION
preResult при локальном выравнивании может начинаться с операции в любом месте строки, поэтому чтобы получить полный список операций ему нужно добавить недостающие операции удаления или вставки вначало. 
Кроме того, если нет ни одного совпадения, preResult может быть вообще пустым. Тогда генерируемый префикс и суффик будут совпадать и в результате дублироваться. Поэтому в этом случае нужно брать только что-то одно. 
Поправил эти проблемы. 