### PR TITLE
Introduce unsafeRead for ChainLike for performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,16 @@ cache:
 
 matrix:
   include:
-  - env: GHCVER=8.6.4 STACK_YAML=stack.yaml
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-8.6.4
+    - ghc: 8.6.4
+      env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 before_install:
 - mkdir -p ~/.local/bin
-- export PATH=/opt/ghc/$GHCVER/bin:$HOME/.local/bin:$PATH
+- export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 install:
-  - travis_wait stack --no-terminal --skip-ghc-check setup
-  - travis_wait stack --no-terminal --skip-ghc-check test --only-snapshot
+  - travis_wait stack --no-terminal --system-ghc test --only-snapshot
 
 script:
-  - stack --pedantic --no-terminal --skip-ghc-check test
+  - stack --no-terminal --system-ghc test --pedantic

--- a/src/Bio/Chain/Alignment/Algorithms.hs
+++ b/src/Bio/Chain/Alignment/Algorithms.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TupleSections #-}
 module Bio.Chain.Alignment.Algorithms where
 
-import           Control.Lens             (Index, IxValue, ix, (^?!))
+import           Control.Lens             (Index, IxValue)
 import qualified Data.Array.Unboxed       as A (bounds, range)
 import           Data.List                (maximumBy)
 
@@ -32,7 +32,7 @@ data SemiglobalAlignment a e1 e2 = SemiglobalAlignment (Scoring e1 e2) a
 {-# SPECIALISE substitute :: (Char -> Char -> Int) -> Chain Int Char -> Chain Int Char -> Int -> Int -> Int #-}
 {-# INLINE substitute #-}
 substitute :: (Alignable m, Alignable m') => (IxValue m -> IxValue m' -> Int) -> m -> m' -> Index m -> Index m' -> Int
-substitute f s t i j = f (s ^?! ix (pred i)) (t ^?! ix (pred j))
+substitute f s t i j = f (s `unsafeRead` (pred i)) (t `unsafeRead` (pred j))
 
 -- | Simple substitution function for edit distance
 --


### PR DESCRIPTION
Alignment must do a lot of array index lookups, doing them with lenses
is slow. This commit adds unsafeRead that does not use lenses and does
not do bounds checking with Int-indexed arrays.