### PR TITLE
Show monomer [a] as simple string

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230321
+# version: 0.16.3
 #
-# REGENDATA ("0.15.20230321",["github","cabal.project"])
+# REGENDATA ("0.16.3",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,14 +28,24 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.6.1
+            compilerKind: ghc
+            compilerVersion: 9.6.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.5
+          - compiler: ghc-9.2.7
             compilerKind: ghc
-            compilerVersion: 9.2.5
+            compilerVersion: 9.2.7
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
@@ -119,8 +129,8 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan

--- a/package.yaml
+++ b/package.yaml
@@ -25,13 +25,16 @@ default-extensions:
 - DeriveFunctor
 - DeriveGeneric
 - DeriveTraversable
+- DerivingVia
 - FlexibleContexts
 - FlexibleInstances
 - GeneralizedNewtypeDeriving
 - MultiWayIf
+- OverloadedStrings
 - RankNTypes
 - RecordWildCards
 - ScopedTypeVariables
+- StandaloneDeriving
 - TypeApplications
 - TypeFamilies
 - TypeOperators
@@ -39,7 +42,7 @@ default-extensions:
 - UndecidableInstances
 
 dependencies:
-- base >= 4.9 && < 5
+- base >= 4.12 && < 5
 - array
 - bytestring
 - containers

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                cobot
-version:             0.1.1.8
+version:             0.1.2.0
 github:              "biocad/cobot"
 license:             BSD-3-Clause
 author:              "Pavel Yakovlev, Bogdan Neterebskii, Alexander Sadovnikov"

--- a/package.yaml
+++ b/package.yaml
@@ -15,8 +15,10 @@ extra-source-files:
 
 tested-with:
   GHC ==8.10.7
-   || ==9.2.5
+   || ==9.0.2
+   || ==9.2.7
    || ==9.4.4
+   || ==9.6.1
 
 default-extensions:
 - AllowAmbiguousTypes

--- a/src/Bio/Chain/Alignment/Scoring/Loader.hs
+++ b/src/Bio/Chain/Alignment/Scoring/Loader.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 module Bio.Chain.Alignment.Scoring.Loader where
 
-import           Control.Applicative             ( liftA2 )
+-- https://github.com/haskell/core-libraries-committee/blob/main/guides/export-lifta2-prelude.md
+import Prelude hiding (Applicative(..))
+import Control.Applicative (Applicative(..))
 
 class ScoringMatrix a where
     scoring :: a -> Char -> Char -> Int
@@ -16,11 +18,11 @@ loadMatrix txt = concatMap (lineMap . words) (tail txtlns)
     -- Letters of matrix
     letters :: [Char]
     !letters = (map head . words . head) txtlns
-    
+
     -- Strip spaces
     strip :: String -> String
     strip = reverse . dropWhile (== ' ') . reverse . dropWhile (== ' ')
-    
+
     -- Map one line to a matrix
     lineMap :: [String] -> [((Char, Char), Int)]
     lineMap []       = []

--- a/src/Bio/NucleicAcid/Nucleotide/Instances.hs
+++ b/src/Bio/NucleicAcid/Nucleotide/Instances.hs
@@ -3,7 +3,7 @@
 module Bio.NucleicAcid.Nucleotide.Instances () where
 
 import           Bio.NucleicAcid.Nucleotide.Type
-import           Bio.Utils.Monomer               (FromSymbol (..), Symbol (..))
+import           Bio.Utils.Monomer               (FromSymbol (..), Symbol (..), ShowMonomer(..))
 import           Data.Array                      (Array, listArray)
 import           Data.String                     (IsString (..))
 
@@ -24,6 +24,8 @@ instance FromSymbol DNA where
     fromSymbolE 'T' = Right DT
     fromSymbolE ch  = Left ch
 
+deriving via ShowMonomer DNA instance Show DNA
+
 instance Symbol RNA where
     symbol RA = 'A'
     symbol RC = 'C'
@@ -36,6 +38,8 @@ instance FromSymbol RNA where
     fromSymbolE 'G' = Right RG
     fromSymbolE 'U' = Right RU
     fromSymbolE ch  = Left ch
+
+deriving via ShowMonomer RNA instance Show RNA
 
 -------------------------------------------------------------------------------
 -- IsString

--- a/src/Bio/NucleicAcid/Nucleotide/Type.hs
+++ b/src/Bio/NucleicAcid/Nucleotide/Type.hs
@@ -15,6 +15,8 @@ import Data.Array      (Array, Ix, bounds, ixmap, listArray)
 import Data.Foldable   (Foldable (..))
 import GHC.Generics    (Generic)
 
+import Bio.Utils.Monomer (FullName (..))
+
 data DNA
   = DA
   | DC
@@ -22,11 +24,11 @@ data DNA
   | DT
   deriving (Eq, Ord, Bounded, Enum, Generic, NFData)
 
-instance Show DNA where
-    show DA = "Adenine"
-    show DC = "Cytosine"
-    show DG = "Guanine"
-    show DT = "Thymine"
+instance FullName DNA where
+    fullName DA = "Adenine"
+    fullName DC = "Cytosine"
+    fullName DG = "Guanine"
+    fullName DT = "Thymine"
 
 data RNA
   = RA
@@ -35,11 +37,11 @@ data RNA
   | RU
   deriving (Eq, Ord, Bounded, Enum, Generic, NFData)
 
-instance Show RNA where
-    show RA = "Adenine"
-    show RC = "Cytosine"
-    show RG = "Guanine"
-    show RU = "Uracil"
+instance FullName RNA where
+    fullName RA = "Adenine"
+    fullName RC = "Cytosine"
+    fullName RG = "Guanine"
+    fullName RU = "Uracil"
 
 -------------------------------------------------------------------------------
 -- Transciption

--- a/src/Bio/Protein/AminoAcid/Instances.hs
+++ b/src/Bio/Protein/AminoAcid/Instances.hs
@@ -1,18 +1,15 @@
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Bio.Protein.AminoAcid.Instances where
 
-import           Bio.Protein.AminoAcid.Type
-import           Bio.Utils.Monomer          (FromSymbol (..),
-                                             FromThreeSymbols (..), Symbol (..),
-                                             ThreeSymbols (..))
-import           Control.Lens               (Const (..), Getting, Identity (..),
-                                             Lens', coerced, to, (^.))
-import           Data.Array                 (Array, listArray)
-import           Data.Coerce                (coerce)
-import           Data.Kind                  (Type)
-import           Data.String                (IsString (..))
+import Bio.Protein.AminoAcid.Type
+import Bio.Utils.Monomer          (FromSymbol (..), FromThreeSymbols (..), ShowMonomer (..),
+                                   Symbol (..), ThreeSymbols (..))
+import Control.Lens               (Const (..), Getting, Identity (..), Lens', coerced, to, (^.))
+import Data.Array                 (Array, listArray)
+import Data.Coerce                (coerce)
+import Data.Kind                  (Type)
+import Data.String                (IsString (..))
 
 -------------------------------------------------------------------------------
 -- Creatable
@@ -238,6 +235,10 @@ instance Symbol AA where
     symbol VAL = 'V'
     symbol TRP = 'W'
     symbol TYR = 'Y'
+
+deriving via ShowMonomer AA instance Show AA
+
+deriving instance Show a => Show (CG a)
 
 -- | Parse symbol encoding
 --

--- a/src/Bio/Protein/AminoAcid/Type.hs
+++ b/src/Bio/Protein/AminoAcid/Type.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass  #-}
-{-# LANGUAGE DeriveFunctor   #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Bio.Protein.AminoAcid.Type where
@@ -7,6 +6,8 @@ module Bio.Protein.AminoAcid.Type where
 import           Control.DeepSeq (NFData (..))
 import           Control.Lens
 import           GHC.Generics    (Generic (..))
+
+import           Bio.Utils.Monomer (FullName (..))
 
 -- | Proteinogenic amino acids
 --
@@ -32,29 +33,27 @@ data AA = ALA -- A
         | TYR -- Y
   deriving (Eq, Ord, Bounded, Enum, Generic, NFData)
 
--- | Show full names of amino acids
---
-instance Show AA where
-    show ALA = "Alanine"
-    show CYS = "Cysteine"
-    show ASP = "AsparticAcid"
-    show GLU = "GlutamicAcid"
-    show PHE = "Phenylalanine"
-    show GLY = "Glycine"
-    show HIS = "Histidine"
-    show ILE = "Isoleucine"
-    show LYS = "Lysine"
-    show LEU = "Leucine"
-    show MET = "Methionine"
-    show ASN = "Asparagine"
-    show PRO = "Proline"
-    show GLN = "Glutamine"
-    show ARG = "Arginine"
-    show SER = "Serine"
-    show THR = "Threonine"
-    show VAL = "Valine"
-    show TRP = "Tryptophan"
-    show TYR = "Tyrosine"
+instance FullName AA where
+  fullName ALA = "Alanine"
+  fullName CYS = "Cysteine"
+  fullName ASP = "AsparticAcid"
+  fullName GLU = "GlutamicAcid"
+  fullName PHE = "Phenylalanine"
+  fullName GLY = "Glycine"
+  fullName HIS = "Histidine"
+  fullName ILE = "Isoleucine"
+  fullName LYS = "Lysine"
+  fullName LEU = "Leucine"
+  fullName MET = "Methionine"
+  fullName ASN = "Asparagine"
+  fullName PRO = "Proline"
+  fullName GLN = "Glutamine"
+  fullName ARG = "Arginine"
+  fullName SER = "Serine"
+  fullName THR = "Threonine"
+  fullName VAL = "Valine"
+  fullName TRP = "Tryptophan"
+  fullName TYR = "Tyrosine"
 
 -- | Amino acid structure type
 --
@@ -217,7 +216,7 @@ data OXT a = OXT { _o'   :: a
 data CG a = CG { _cg'      :: a
                , _radical' :: AA
                }
-  deriving (Show, Eq, Functor, Generic, NFData)
+  deriving (Eq, Functor, Generic, NFData)
 
 makeLenses ''AminoAcid
 makeLenses ''Radical

--- a/src/Bio/Utils/Monomer.hs
+++ b/src/Bio/Utils/Monomer.hs
@@ -3,9 +3,13 @@ module Bio.Utils.Monomer
   , FromSymbol(..)
   , ThreeSymbols(..)
   , FromThreeSymbols (..)
+  , FullName(..)
+
+  , ShowMonomer (..)
   ) where
 
 import           Data.Text                      ( Text )
+import           Data.Coerce                    ( coerce )
 
 class Symbol a where
     symbol :: a -> Char
@@ -28,3 +32,14 @@ class ThreeSymbols a where
 
 class FromThreeSymbols a where
     fromThreeSymbols :: Text -> Maybe a
+
+-- | Full name of monomer, like "Adenosine" or "Lysine".
+class FullName a where
+    fullName :: a -> String
+
+-- | DerivingVia wrapper to 'show' @[a]@ as a string of one-symbol encoding.
+newtype ShowMonomer a = ShowMonomer a
+
+instance Symbol a => Show (ShowMonomer a) where
+    show (ShowMonomer nc) = [symbol nc]
+    showList = foldMap (showChar . symbol . coerce @_ @a)

--- a/test/HandcraftedSpec.hs
+++ b/test/HandcraftedSpec.hs
@@ -63,7 +63,7 @@ handcraftedLocal = do
         s1ans = "SSSLNRTTT"
         s2ans = "SSS---TTT"
 
-        res = testAlign s1 s2
+        res = testAlign (s1 :: String) (s2 :: String)
         (s1', s2') = viewAlignment res
 
     it "first sequence"  $ s1' `shouldBe` s1ans

--- a/test/JuliaSpec.hs
+++ b/test/JuliaSpec.hs
@@ -74,7 +74,7 @@ juliaGlobal = do
 
   describe "GlobalAlignment. AffineGap" $ do
     let testAlign = align (GlobalAlignment nuc44 (AffineGap (-5) (-1)))
-        res1 = testAlign "AGGT" "CAAT"
+        res1 = testAlign ("AGGT" :: String) ("CAAT" :: String)
         res2 = testAlign "AGGTACC" "CAATG"
 
     -- Честно посчитано руками в тетради


### PR DESCRIPTION
No more `[Adenosine, Guanine, Thymine]`, now it's `"AGT"`.